### PR TITLE
웹소켓 구독 복구 버그 수정

### DIFF
--- a/pykis/client/websocket.py
+++ b/pykis/client/websocket.py
@@ -187,18 +187,19 @@ class KisWebsocketClient:
                 logging.logger.info("RTC Disconnecting from server")
                 self.websocket.close()
 
-    def _request(self, type: str, body: KisWebsocketForm | None = None) -> bool:
+    def _request(self, type: str, body: KisWebsocketForm | None = None, force: bool = False) -> bool:
         """
         요청을 보냅니다.
 
         Args:
             type (str): 요청 타입
             body (KisWebsocketForm | None): 요청 본문
+            force (bool): 접속 상태와 상관없이 요청을 보낼지 여부
 
         Returns:
             bool: 요청 성공 여부
         """
-        if not self.websocket or not self._connected_event.is_set():
+        if not self.websocket or (not force and not self._connected_event.is_set()):
             return False
 
         logging.logger.debug("RTC Sending request: %s %s", type, body)
@@ -355,7 +356,7 @@ class KisWebsocketClient:
         logging.logger.info("RTC Restoring subscriptions... %s", ", ".join(map(str, subscriptions)))
 
         for tr in subscriptions:
-            self._request(TR_SUBSCRIBE_TYPE, tr)
+            self._request(TR_SUBSCRIBE_TYPE, tr, force=True)
 
     def _run_forever(self) -> bool:
         SLEEP_INTERVAL = 0.1


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

초기 웹소켓 이벤트 구독시 클라이언트 접속 후 구독을 요청하는 코드에서 `_connected_event`가 set 되어있지 않아, 요청이 무시되는 버그를 수정했습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `client/websocket.py` 파일의 `KisWebsocketClient._request` 함수에 파라미터 `force`를 추가했습니다.
  `force=True`이면 `_connected_event`를 무시합니다.


## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  웹소켓 구독시 클라이언트 접속 후 구독을 복구하지 못하는 문제를 해결합니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  정상적인 lazy 구독을 하도록 변경하였습니다.
