### PR TITLE
정수 수량 매매 지원

### DIFF
--- a/pykis/__init__.py
+++ b/pykis/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "ORDER_EXECUTION",
     "ORDER_CONDITION",
     "ORDER_QUANTITY",
+    "IN_ORDER_QUANTITY",
     ################################
     ##             API            ##
     ################################

--- a/pykis/adapter/account/order.py
+++ b/pykis/adapter/account/order.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from pykis.api.account.order import (
+    IN_ORDER_QUANTITY,
     ORDER_CONDITION,
     ORDER_EXECUTION,
     ORDER_PRICE,
-    ORDER_QUANTITY,
     ORDER_TYPE,
     KisOrder,
     KisOrderNumber,
@@ -33,7 +33,7 @@ class KisOrderableAccount(Protocol):
         market: MARKET_TYPE,
         symbol: str,
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -48,7 +48,7 @@ class KisOrderableAccount(Protocol):
             market (MARKET_TYPE): 시장
             symbol (str): 종목코드
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -102,7 +102,7 @@ class KisOrderableAccount(Protocol):
         market: MARKET_TYPE,
         symbol: str,
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -117,7 +117,7 @@ class KisOrderableAccount(Protocol):
             market (MARKET_TYPE): 시장
             symbol (str): 종목코드
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -172,7 +172,7 @@ class KisOrderableAccount(Protocol):
         symbol: str,
         order: ORDER_TYPE,
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -188,7 +188,7 @@ class KisOrderableAccount(Protocol):
             symbol (str): 종목코드
             order (ORDER_TYPE): 주문종류
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -275,7 +275,7 @@ class KisOrderableAccount(Protocol):
         self: "KisAccountProtocol",
         order: KisOrderNumber,
         price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
         execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
     ) -> KisOrder:
@@ -290,7 +290,7 @@ class KisOrderableAccount(Protocol):
             account (str | KisAccountNumber): 계좌번호
             order (KisOrderNumber): 주문번호
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         """

--- a/pykis/adapter/account_product/order.py
+++ b/pykis/adapter/account_product/order.py
@@ -1,7 +1,7 @@
-from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
 from pykis.api.account.order import (
+    IN_ORDER_QUANTITY,
     ORDER_CONDITION,
     ORDER_EXECUTION,
     ORDER_PRICE,
@@ -28,7 +28,7 @@ class KisOrderableAccountProduct(Protocol):
         self: "KisAccountProductProtocol",
         order: ORDER_TYPE,
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -42,7 +42,7 @@ class KisOrderableAccountProduct(Protocol):
         Args:
             order (ORDER_TYPE): 주문종류
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -128,7 +128,7 @@ class KisOrderableAccountProduct(Protocol):
     def buy(
         self: "KisAccountProductProtocol",
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -141,7 +141,7 @@ class KisOrderableAccountProduct(Protocol):
 
         Args:
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -193,7 +193,7 @@ class KisOrderableAccountProduct(Protocol):
     def sell(
         self: "KisAccountProductProtocol",
         price: ORDER_PRICE | None = None,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None = None,
         execution: ORDER_EXECUTION | None = None,
         include_foreign: bool = False,
@@ -206,7 +206,7 @@ class KisOrderableAccountProduct(Protocol):
 
         Args:
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
             include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부

--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -44,7 +44,10 @@ __all__ = [
 
 @runtime_checkable
 class KisBalanceStock(
-    KisAccountProductProtocol, KisOrderableAccountProduct, KisWebsocketQuotableProduct, Protocol
+    KisAccountProductProtocol,
+    KisOrderableAccountProduct,
+    KisWebsocketQuotableProduct,
+    Protocol,
 ):
     """한국투자증권 보유종목"""
 

--- a/pykis/api/account/order.py
+++ b/pykis/api/account/order.py
@@ -63,6 +63,9 @@ ORDER_PRICE = Decimal | int | float
 ORDER_QUANTITY = Decimal
 """주문 수량"""
 
+IN_ORDER_QUANTITY = Decimal | int | float
+"""주문 수량"""
+
 
 def ensure_price(price: ORDER_PRICE, digit: int | None = 4) -> Decimal:
     """
@@ -79,6 +82,23 @@ def ensure_price(price: ORDER_PRICE, digit: int | None = 4) -> Decimal:
         price = price.quantize(Decimal(f"1e{-digit}"))
 
     return price
+
+
+def ensure_quantity(quantity: IN_ORDER_QUANTITY, digit: int | None = 0) -> ORDER_QUANTITY:
+    """
+    주문 수량을 Decimal로 변환합니다.
+
+    Args:
+        quantity (IN_ORDER_QUANTITY): 주문 수량
+        digit (int | None, optional): 소수점 자릿수 (내림)
+    """
+    if not isinstance(quantity, ORDER_QUANTITY):
+        quantity = ORDER_QUANTITY(quantity)
+
+    if digit is not None:
+        quantity = quantity.quantize(Decimal(f"1e{-digit}"))
+
+    return quantity
 
 
 ORDER_EXECUTION = Literal[
@@ -372,7 +392,7 @@ class KisOrder(KisOrderNumber, KisRealtimeOrderableAccount, Protocol):
     def modify(
         self,
         price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
         execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
     ) -> "KisOrder":
@@ -384,7 +404,7 @@ class KisOrder(KisOrderNumber, KisRealtimeOrderableAccount, Protocol):
 
         Args:
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         """
@@ -722,7 +742,7 @@ class KisOrderBase(KisOrderNumberBase):
     def modify(
         self,
         price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-        qty: ORDER_QUANTITY | None = None,
+        qty: IN_ORDER_QUANTITY | None = None,
         condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
         execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
     ) -> KisOrder:
@@ -734,7 +754,7 @@ class KisOrderBase(KisOrderNumberBase):
 
         Args:
             price (ORDER_PRICE, optional): 주문가격
-            qty (ORDER_QUANTITY, optional): 주문수량
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
             condition (ORDER_CONDITION, optional): 주문조건
             execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         """
@@ -952,7 +972,6 @@ def _orderable_quantity(
     symbol: str,
     order: ORDER_TYPE = "buy",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -975,7 +994,6 @@ def _orderable_quantity(
         symbol (str): 종목코드
         order (ORDER_TYPE, optional): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1047,7 +1065,7 @@ def domestic_order(
     symbol: str,
     order: ORDER_TYPE = "buy",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1063,7 +1081,7 @@ def domestic_order(
         symbol (str): 종목코드
         order (ORDER_TYPE, optional): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1215,7 +1233,7 @@ def foreign_order(
     symbol: str,
     order: ORDER_TYPE = "buy",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: FOREIGN_ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1232,7 +1250,7 @@ def foreign_order(
         symbol (str): 종목코드
         order (ORDER_TYPE, optional): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1349,7 +1367,7 @@ def foreign_daytime_order(
     symbol: str,
     order: ORDER_TYPE = "buy",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     include_foreign: bool = False,
 ) -> KisForeignDaytimeOrder:
     """
@@ -1364,7 +1382,7 @@ def foreign_daytime_order(
         symbol (str): 종목코드
         order (ORDER_TYPE, optional): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
     """
     if self.virtual:
@@ -1432,7 +1450,7 @@ def order(
     symbol: str,
     order: ORDER_TYPE,
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1449,7 +1467,7 @@ def order(
         symbol (str): 종목코드
         order (ORDER_TYPE): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1581,7 +1599,7 @@ def account_order(
     symbol: str,
     order: ORDER_TYPE,
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1597,7 +1615,7 @@ def account_order(
         symbol (str): 종목코드
         order (ORDER_TYPE): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1697,7 +1715,7 @@ def account_buy(
     market: MARKET_TYPE,
     symbol: str,
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1712,7 +1730,7 @@ def account_buy(
         market (MARKET_TYPE): 시장
         symbol (str): 종목코드
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1777,7 +1795,7 @@ def account_sell(
     market: MARKET_TYPE,
     symbol: str,
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1792,7 +1810,7 @@ def account_sell(
         market (MARKET_TYPE): 시장
         symbol (str): 종목코드
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1856,7 +1874,7 @@ def account_product_order(
     self: "KisAccountProductProtocol",
     order: ORDER_TYPE,
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1870,7 +1888,7 @@ def account_product_order(
     Args:
         order (ORDER_TYPE): 주문종류
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -1968,7 +1986,7 @@ def account_product_order(
 def account_product_buy(
     self: "KisAccountProductProtocol",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -1981,7 +1999,7 @@ def account_product_buy(
 
     Args:
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부
@@ -2042,7 +2060,7 @@ def account_product_buy(
 def account_product_sell(
     self: "KisAccountProductProtocol",
     price: ORDER_PRICE | None = None,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None = None,
     execution: ORDER_EXECUTION | None = None,
     include_foreign: bool = False,
@@ -2055,7 +2073,7 @@ def account_product_sell(
 
     Args:
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (DOMESTIC_ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
         include_foreign (bool, optional): 전량 주문시 외화 주문가능금액 포함 여부

--- a/pykis/api/account/order_modify.py
+++ b/pykis/api/account/order_modify.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from pykis.api.account.order import (
+    IN_ORDER_QUANTITY,
     ORDER_CONDITION,
     ORDER_EXECUTION,
     ORDER_PRICE,
@@ -106,7 +107,7 @@ def domestic_modify_order(
     self: "PyKis",
     order: KisOrderNumber,
     price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
     execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
 ) -> KisDomesticModifyOrder:
@@ -119,7 +120,7 @@ def domestic_modify_order(
     Args:
         order (KisOrderNumber): 주문번호
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
     """
@@ -262,7 +263,7 @@ def foreign_modify_order(
     self: "PyKis",
     order: KisOrderNumber,
     price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
     execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
 ) -> KisForeignModifyOrder:
@@ -275,7 +276,7 @@ def foreign_modify_order(
     Args:
         order (KisOrderNumber): 주문번호
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
     """
@@ -392,7 +393,7 @@ def foreign_daytime_modify_order(
     self: "PyKis",
     order: KisOrderNumber,
     price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
 ) -> KisForeignDaytimeModifyOrder:
     """
     한국투자증권 해외 주간거래 주문정정
@@ -403,7 +404,7 @@ def foreign_daytime_modify_order(
     Args:
         order (KisOrderNumber): 주문번호
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
     """
@@ -524,7 +525,7 @@ def modify_order(
     self: "PyKis",
     order: KisOrderNumber,
     price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
     execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
 ) -> KisOrder:
@@ -538,7 +539,7 @@ def modify_order(
     Args:
         order (KisOrderNumber): 주문번호
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
     """
@@ -577,7 +578,7 @@ def account_modify_order(
     self: "KisAccountProtocol",
     order: KisOrderNumber,
     price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-    qty: ORDER_QUANTITY | None = None,
+    qty: IN_ORDER_QUANTITY | None = None,
     condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
     execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
 ) -> KisOrder:
@@ -592,7 +593,7 @@ def account_modify_order(
         account (str | KisAccountNumber): 계좌번호
         order (KisOrderNumber): 주문번호
         price (ORDER_PRICE, optional): 주문가격
-        qty (ORDER_QUANTITY, optional): 주문수량
+        qty (IN_ORDER_QUANTITY, optional): 주문수량
         condition (ORDER_CONDITION, optional): 주문조건
         execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
     """

--- a/pykis/client/object.py
+++ b/pykis/client/object.py
@@ -36,10 +36,10 @@ class KisObjectBase:
         라이브러리 내에서는 해당 속성을 사용할 때 초기화 단계에서 사용하지 않도록 해야합니다.
     """
 
-    def __kis_init__(self, kis: "PyKis"):
+    def __kis_init__(self, kis: "PyKis") -> None:
         self.kis = kis
 
-    def __kis_post_init__(self):
+    def __kis_post_init__(self) -> None:
         pass
 
     def _kis_spread(

--- a/pykis/types.py
+++ b/pykis/types.py
@@ -7,6 +7,7 @@ from pykis.adapter.websocket.price import KisWebsocketQuotableProduct
 from pykis.api.account.balance import KisBalance, KisBalanceStock, KisDeposit
 from pykis.api.account.daily_order import KisDailyOrder, KisDailyOrders
 from pykis.api.account.order import (
+    IN_ORDER_QUANTITY,
     ORDER_CONDITION,
     ORDER_EXECUTION,
     ORDER_PRICE,
@@ -115,6 +116,7 @@ __all__ = [
     "ORDER_EXECUTION",
     "ORDER_CONDITION",
     "ORDER_QUANTITY",
+    "IN_ORDER_QUANTITY",
     ################################
     ##             API            ##
     ################################


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

입력되는 주문 수량에 int형, float형을 지원하도록 구현하였습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `api/account/order.py`에 `IN_ORDER_QUANTITY = Decimal | int | float` 타입을 추가하고, `ensure_quantity` 함수를 추가하였습니다.
- 이외의 주문 수량 함수 호출 파라미터에 `IN_ORDER_QUANTITY` 타입을 사용하도록 변경하였습니다.


## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  주문 수량을 Decimal이외의 기본 python 숫자형도 사용할 수 있도록 수정하여 사용성을 높입니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  주문 수량을 일반 정수형으로 지정할 수 있어 개발 부담이 줄어듭니다.
