### PR TITLE
해외주식 잔고 수량 버그 수정

### DIFF
--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -1058,16 +1058,19 @@ def foreign_balance(
         ),
     )
 
-    if self.virtual:
-        result.stocks = _foreign_balance(
-            self,
-            account=account,
-            country=country,
-        ).stocks
+    # Issue #41 - [버그]: KisIntegrationBalance에서 해외주식 잔고수량이 0으로 표시됨
+    # https://apiportal.koreainvestment.com/apiservice/apiservice-oversea-stock-order#L_09baff2a-6e9d-4502-ba66-d7bb94094b67
+    # 위 Docs와 같이 "잔고 확인을 원하실 경우에는 해외주식 잔고[v1_해외주식-006] API 사용을 부탁드립니다.)" 라고 되어있음
+    
+    result.stocks = _foreign_balance(
+        self,
+        account=account,
+        country=country,
+    ).stocks
 
-        for stock in result.stocks:
-            if isinstance(stock, KisBalanceStockBase):
-                stock.balance = result
+    for stock in result.stocks:
+        if isinstance(stock, KisBalanceStockBase):
+            stock.balance = result
 
     return result
 


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

실전계좌에서 해외주식의 보유 수량이 0인 문제를 해결했습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `api/account/balance.py` 파일에서 `foreign_balance` 함수의 `if self.virtual:`을 제거했습니다.

## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  보유수량 버그를 수정했습니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  실전 계좌도 잔고 조회 API를 호출하도록 변경했습니다.
