### PR TITLE
국내주식 시세조회의 업종명 버그 수정

### DIFF
--- a/pykis/api/stock/info.py
+++ b/pykis/api/stock/info.py
@@ -181,7 +181,7 @@ class KisStockInfoResponse(KisStockInfo, KisResponseProtocol, Protocol):
     "market",
     "symbol",
     "name",
-    "eng_name",
+    "name_eng",
     lines="single",
 )
 class KisStockInfoRepr:

--- a/pykis/api/stock/quote.py
+++ b/pykis/api/stock/quote.py
@@ -75,7 +75,7 @@ class KisQuote(KisProductProtocol, Protocol):
     """한국투자증권 상품 시세"""
 
     @property
-    def sector_name(self) -> str:
+    def sector_name(self) -> str | None:
         """업종명"""
         raise NotImplementedError
 
@@ -301,7 +301,7 @@ class KisQuoteBase(KisQuoteRepr, KisProductBase):
     market: MARKET_TYPE
     """상품유형타입"""
 
-    sector_name: str
+    sector_name: str | None
     """업종명"""
     price: Decimal
     """현재가"""
@@ -402,7 +402,7 @@ class KisDomesticQuote(KisQuoteBase, KisAPIResponse):
     market: MARKET_TYPE
     """상품유형타입"""
 
-    sector_name: str = KisString["bstp_kor_isnm"]
+    sector_name: str | None = KisString["bstp_kor_isnm", None]
     """업종명"""
     price: Decimal = KisDecimal["stck_prpr"]
     """현재가"""
@@ -516,7 +516,7 @@ class KisForeignQuote(KisQuoteBase, KisAPIResponse):
     market: MARKET_TYPE
     """상품유형타입"""
 
-    sector_name: str = KisString["e_icod"]
+    sector_name: str | None = KisString["e_icod"]
     """업종명"""
     price: Decimal = KisDecimal["last"]
     """현재가"""

--- a/tests/unit/test_product_quote.py
+++ b/tests/unit/test_product_quote.py
@@ -25,6 +25,9 @@ class ProductQuoteTests(TestCase):
 
     def test_krx_quote(self):
         self.assertTrue(isinstance(self.pykis.stock("005930").quote(), KisQuote))
+        # https://github.com/Soju06/python-kis/issues/48
+        # bstp_kor_isnm 필드 누락 대응
+        self.assertTrue(isinstance(self.pykis.stock("002170").quote(), KisQuote))
 
     def test_nasd_quote(self):
         self.assertTrue(isinstance(self.pykis.stock("NVDA").quote(), KisQuote))


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

국내주식 시세조회의 업종명이 없을때 발생하는 버그를 수정했습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `pykis/api/stock/quote.py`에서 sector_name을 optional로 변경하고 `bstp_kor_isnm` 필드의 기본값을 None로 설정했습니다.
- `pykis/api/stock/info.py`의 repr에서 잘못된 속성 `eng_name`를 `name_eng`로 변경했습니다.

## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  업종명이 없는 종목의 조회시 오류가 발생하는 문제를 해결했습니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  국내주식 시세조회 및 `KisStockInfo`의 repr가 정상적으로 작동합니다.
