### PR TITLE
미체결 주문 객체 KisOrder 프로토콜 지원

### DIFF
--- a/pykis/adapter/account_product/order_modify.py
+++ b/pykis/adapter/account_product/order_modify.py
@@ -32,10 +32,10 @@ class KisModifyableOrder(Protocol):
 
     def modify(
         self,
-        price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-        qty: IN_ORDER_QUANTITY | None = None,
-        condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
-        execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
+        price: "ORDER_PRICE | None | EMPTY_TYPE" = EMPTY,
+        qty: "IN_ORDER_QUANTITY | None" = None,
+        condition: "ORDER_CONDITION | None | EMPTY_TYPE" = EMPTY,
+        execution: "ORDER_EXECUTION | None | EMPTY_TYPE" = EMPTY,
     ) -> "KisOrder":
         """
         한국투자증권 통합 주식 주문정정 (국내 모의투자 미지원, 해외 주간거래 모의투자 미지원)
@@ -79,10 +79,10 @@ class KisModifyableOrderImpl:
 
     def modify(
         self: "KisOrderNumber",
-        price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
-        qty: IN_ORDER_QUANTITY | None = None,
-        condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
-        execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
+        price: "ORDER_PRICE | None | EMPTY_TYPE" = EMPTY,
+        qty: "IN_ORDER_QUANTITY | None" = None,
+        condition: "ORDER_CONDITION | None | EMPTY_TYPE" = EMPTY,
+        execution: "ORDER_EXECUTION | None | EMPTY_TYPE" = EMPTY,
     ) -> "KisOrder":
         """
         한국투자증권 통합 주식 주문정정 (국내 모의투자 미지원, 해외 주간거래 모의투자 미지원)

--- a/pykis/adapter/account_product/order_modify.py
+++ b/pykis/adapter/account_product/order_modify.py
@@ -1,0 +1,112 @@
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from pykis.utils.params import EMPTY, EMPTY_TYPE
+
+if TYPE_CHECKING:
+    from pykis.api.account.order import (
+        IN_ORDER_QUANTITY,
+        ORDER_CONDITION,
+        ORDER_EXECUTION,
+        ORDER_PRICE,
+        KisOrder,
+        KisOrderNumber,
+    )
+
+
+@runtime_checkable
+class KisCancelableOrder(Protocol):
+    """취소 가능 주문 프로토콜"""
+
+    def cancel(self) -> "KisOrder":
+        """
+        한국투자증권 통합 주식 주문취소 (해외 주간거래 모의투자 미지원)
+
+        국내주식주문 -> 주식주문(정정취소)[v1_국내주식-003]
+        국내주식주문 -> 해외주식 정정취소주문[v1_해외주식-003]
+        """
+        raise NotImplementedError
+
+
+class KisModifyableOrder(Protocol):
+    """정정 가능 주문 프로토콜"""
+
+    def modify(
+        self,
+        price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
+        qty: IN_ORDER_QUANTITY | None = None,
+        condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
+        execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
+    ) -> "KisOrder":
+        """
+        한국투자증권 통합 주식 주문정정 (국내 모의투자 미지원, 해외 주간거래 모의투자 미지원)
+
+        국내주식주문 -> 주식주문(정정취소)[v1_국내주식-003]
+        국내주식주문 -> 해외주식 정정취소주문[v1_해외주식-003]
+
+        Args:
+            price (ORDER_PRICE, optional): 주문가격
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
+            condition (ORDER_CONDITION, optional): 주문조건
+            execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class KisOrderableOrder(KisCancelableOrder, KisModifyableOrder, Protocol):
+    """주문 가능 주문 프로토콜"""
+
+
+class KisCancelableOrderImpl:
+    """취소 가능 주문"""
+
+    def cancel(
+        self: "KisOrderNumber",
+    ) -> "KisOrder":
+        """
+        한국투자증권 통합 주식 주문취소 (해외 주간거래 모의투자 미지원)
+
+        국내주식주문 -> 주식주문(정정취소)[v1_국내주식-003]
+        국내주식주문 -> 해외주식 정정취소주문[v1_해외주식-003]
+        """
+        from pykis.api.account.order_modify import cancel_order
+
+        return cancel_order(self.kis, order=self)
+
+
+class KisModifyableOrderImpl:
+    """정정 가능 주문"""
+
+    def modify(
+        self: "KisOrderNumber",
+        price: ORDER_PRICE | None | EMPTY_TYPE = EMPTY,
+        qty: IN_ORDER_QUANTITY | None = None,
+        condition: ORDER_CONDITION | None | EMPTY_TYPE = EMPTY,
+        execution: ORDER_EXECUTION | None | EMPTY_TYPE = EMPTY,
+    ) -> "KisOrder":
+        """
+        한국투자증권 통합 주식 주문정정 (국내 모의투자 미지원, 해외 주간거래 모의투자 미지원)
+
+        국내주식주문 -> 주식주문(정정취소)[v1_국내주식-003]
+        국내주식주문 -> 해외주식 정정취소주문[v1_해외주식-003]
+
+        Args:
+            price (ORDER_PRICE, optional): 주문가격
+            qty (IN_ORDER_QUANTITY, optional): 주문수량
+            condition (ORDER_CONDITION, optional): 주문조건
+            execution (ORDER_EXECUTION_CONDITION, optional): 체결조건
+        """
+        from pykis.api.account.order_modify import modify_order
+
+        return modify_order(
+            self.kis,
+            order=self,
+            price=price,
+            qty=qty,
+            condition=condition,
+            execution=execution,
+        )
+
+
+class KisOrderableOrderImpl(KisCancelableOrderImpl, KisModifyableOrderImpl):
+    """주문 가능 주문"""

--- a/pykis/adapter/websocket/execution.py
+++ b/pykis/adapter/websocket/execution.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING, Callable, Literal, Protocol, runtime_checkable
 
 from pykis.api.base.account import KisAccountProtocol
-from pykis.event.handler import KisEventFilter, KisEventTicket
+from pykis.event.handler import KisEventFilter, KisEventTicket, KisMultiEventFilter
 from pykis.event.subscription import KisSubscriptionEventArgs
 
 if TYPE_CHECKING:
+    from pykis.api.account.order import KisOrder
     from pykis.api.websocket.order_execution import KisRealtimeExecution
     from pykis.client.websocket import KisWebsocketClient
 
@@ -22,9 +23,7 @@ class KisRealtimeOrderableAccount(Protocol):
         self,
         event: Literal["execution"],
         callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
-        where: (
-            "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None"
-        ) = None,
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
         once: bool = False,
     ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
         """
@@ -44,9 +43,7 @@ class KisRealtimeOrderableAccount(Protocol):
         self,
         event: Literal["execution"],
         callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
-        where: (
-            "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None"
-        ) = None,
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
     ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
         """
         웹소켓 이벤트 핸들러 등록
@@ -68,9 +65,7 @@ class KisRealtimeOrderableAccountImpl:
         self: "KisAccountProtocol",
         event: Literal["execution"],
         callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
-        where: (
-            "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None"
-        ) = None,
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
         once: bool = False,
     ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
         """
@@ -100,9 +95,7 @@ class KisRealtimeOrderableAccountImpl:
         self: "KisAccountProtocol",
         event: Literal["execution"],
         callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
-        where: (
-            "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None"
-        ) = None,
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
     ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
         """
         웹소켓 이벤트 핸들러 등록
@@ -121,6 +114,68 @@ class KisRealtimeOrderableAccountImpl:
                 self,
                 callback=callback,
                 where=where,
+                once=True,
+            )
+
+        raise ValueError(f"Unknown event: {event}")
+
+
+class KisRealtimeOrderableOrderImpl:
+    """한국투자증권 실시간 주문 가능 주문"""
+
+    def on(
+        self: "KisOrder",
+        event: Literal["execution"],
+        callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
+        once: bool = False,
+    ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
+        """
+        웹소켓 이벤트 핸들러 등록
+
+        [국내주식] 실시간시세 -> 국내주식 실시간체결통보[실시간-005]
+        [해외주식] 실시간시세 -> 해외주식 실시간체결통보[실시간-009]
+
+        Args:
+            callback (Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]): 콜백 함수
+            where (KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None, optional): 이벤트 필터. Defaults to None.
+            once (bool, optional): 한번만 실행 여부. Defaults to False.
+        """
+        from pykis.api.websocket.order_execution import on_account_execution
+
+        if event == "execution":
+            return on_account_execution(
+                self,
+                callback=callback,
+                where=KisMultiEventFilter(self, where) if where else self,
+                once=once,
+            )
+
+        raise ValueError(f"Unknown event: {event}")
+
+    def once(
+        self: "KisOrder",
+        event: Literal["execution"],
+        callback: "Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]",
+        where: "KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None" = None,
+    ) -> "KisEventTicket[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]]":
+        """
+        웹소켓 이벤트 핸들러 등록
+
+        [국내주식] 실시간시세 -> 국내주식 실시간체결통보[실시간-005]
+        [해외주식] 실시간시세 -> 해외주식 실시간체결통보[실시간-009]
+
+        Args:
+            callback (Callable[[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]], None]): 콜백 함수
+            where (KisEventFilter[KisWebsocketClient, KisSubscriptionEventArgs[KisRealtimeExecution]] | None, optional): 이벤트 필터. Defaults to None.
+        """
+        from pykis.api.websocket.order_execution import on_account_execution
+
+        if event == "execution":
+            return on_account_execution(
+                self,
+                callback=callback,
+                where=KisMultiEventFilter(self, where) if where else self,
                 once=True,
             )
 

--- a/pykis/api/account/daily_order.py
+++ b/pykis/api/account/daily_order.py
@@ -9,6 +9,7 @@ from pykis.api.account.order import (
     ORDER_QUANTITY,
     ORDER_TYPE,
     KisOrder,
+    KisSimpleOrder,
 )
 from pykis.api.base.account import KisAccountBase, KisAccountProtocol
 from pykis.api.base.account_product import (
@@ -372,7 +373,7 @@ class KisDomesticDailyOrder(KisDynamic, KisDailyOrderBase):
     @property
     def order_number(self) -> KisOrder:
         """주문번호"""
-        return KisOrder.from_order(
+        return KisSimpleOrder.from_order(
             account_number=self.account_number,
             symbol=self.symbol,
             market=self.market,
@@ -495,7 +496,7 @@ class KisForeignDailyOrder(KisDynamic, KisDailyOrderBase):
     @cached
     def order_number(self) -> KisOrder:
         """주문번호"""
-        return KisOrder.from_order(
+        return KisSimpleOrder.from_order(
             account_number=self.account_number,
             symbol=self.symbol,
             market=self.market,

--- a/pykis/api/account/order.py
+++ b/pykis/api/account/order.py
@@ -37,19 +37,17 @@ from pykis.api.stock.market import (
 from pykis.api.stock.quote import quote
 from pykis.client.account import KisAccountNumber
 from pykis.event.filters.order import KisOrderNumberEventFilter
-from pykis.event.handler import KisEventFilter, KisEventTicket, KisMultiEventFilter
+from pykis.event.handler import KisEventFilter
 from pykis.event.subscription import KisSubscriptionEventArgs
 from pykis.responses.exceptions import KisMarketNotOpenedError
 from pykis.responses.response import KisAPIResponse, raise_not_found
 from pykis.responses.types import KisString
-from pykis.utils.params import EMPTY, EMPTY_TYPE
 from pykis.utils.timezone import TIMEZONE
 from pykis.utils.typing import Checkable
 
 if TYPE_CHECKING:
     from pykis.api.account.pending_order import KisPendingOrder
     from pykis.api.base.account_product import KisAccountProductProtocol
-    from pykis.api.websocket.order_execution import KisRealtimeExecution
     from pykis.client.websocket import KisWebsocketClient
     from pykis.kis import PyKis
 
@@ -528,13 +526,13 @@ class KisOrderNumberBase(KisAccountProductBase, KisOrderNumberEventFilter):
                 and self.symbol == value.symbol  # type: ignore
                 and self.market == value.market  # type: ignore
                 and self.branch == value.branch  # type: ignore
-                and self.number == value.number  # type: ignore
+                and int(self.number) == int(value.number)  # type: ignore
             )
         except AttributeError:
             return False
 
     def __hash__(self) -> int:
-        return hash((self.account_number, self.symbol, self.market, self.branch, self.number))
+        return hash((self.account_number, self.symbol, self.market, self.branch, int(self.number)))
 
     def __repr__(self) -> str:
         return f"""{self.__class__.__name__}(

--- a/pykis/api/account/order_modify.py
+++ b/pykis/api/account/order_modify.py
@@ -6,18 +6,15 @@ from pykis.api.account.order import (
     ORDER_CONDITION,
     ORDER_EXECUTION,
     ORDER_PRICE,
-    ORDER_QUANTITY,
     KisOrder,
     KisOrderBase,
     KisOrderNumber,
-    KisOrderNumberBase,
     ensure_price,
     order_condition,
 )
 from pykis.api.stock.info import get_market_country
 from pykis.api.stock.market import DAYTIME_MARKETS, MARKET_TYPE, get_market_code
 from pykis.api.stock.quote import quote
-from pykis.client.account import KisAccountNumber
 from pykis.client.exceptions import KisAPIError
 from pykis.responses.response import KisAPIResponse
 from pykis.responses.types import KisString

--- a/pykis/api/account/pending_order.py
+++ b/pykis/api/account/pending_order.py
@@ -295,6 +295,9 @@ class KisPendingOrderBase(
         """미체결수량"""
         return self.pending_quantity
 
+    def __init__(self) -> None:
+        super().__init__(lambda: self)
+
     @staticmethod
     @deprecated("Use KisOrder.from_number() instead")
     def from_number(

--- a/pykis/api/account/pending_order.py
+++ b/pykis/api/account/pending_order.py
@@ -3,6 +3,13 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Iterable, Protocol, runtime_checkable
 from zoneinfo import ZoneInfo
 
+from typing_extensions import deprecated
+
+from pykis.adapter.account_product.order_modify import (
+    KisOrderableOrder,
+    KisOrderableOrderImpl,
+)
+from pykis.adapter.websocket.execution import KisRealtimeOrderableOrderImpl
 from pykis.api.account.order import (
     ORDER_CONDITION,
     ORDER_EXECUTION,
@@ -10,6 +17,9 @@ from pykis.api.account.order import (
     ORDER_TYPE,
     KisOrder,
     KisOrderNumber,
+    KisOrderNumberBase,
+    KisSimpleOrder,
+    KisSimpleOrderNumber,
     resolve_domestic_order_condition,
 )
 from pykis.api.base.account import KisAccountBase, KisAccountProtocol
@@ -23,15 +33,16 @@ from pykis.api.stock.market import (
     KisMarketType,
     get_market_code,
     get_market_code_timezone,
-    get_market_timezone,
 )
 from pykis.client.account import KisAccountNumber
 from pykis.client.page import KisPage
+from pykis.event.filters.order import KisOrderNumberEventFilter
 from pykis.responses.dynamic import KisDynamic, KisList
 from pykis.responses.response import KisPaginationAPIResponse
-from pykis.responses.types import KisAny, KisDecimal, KisInt, KisString
+from pykis.responses.types import KisAny, KisDecimal, KisString
 from pykis.utils.repr import kis_repr
 from pykis.utils.timezone import TIMEZONE
+from pykis.utils.typing import Checkable
 
 if TYPE_CHECKING:
     from pykis.kis import PyKis
@@ -44,23 +55,8 @@ __all__ = [
 
 
 @runtime_checkable
-class KisPendingOrder(KisAccountProductProtocol, Protocol):
+class KisPendingOrder(KisOrder, Protocol):
     """한국투자증권 미체결 주식"""
-
-    @property
-    def time(self) -> datetime:
-        """주문시각"""
-        raise NotImplementedError
-
-    @property
-    def time_kst(self) -> datetime:
-        """주문시각(KST)"""
-        raise NotImplementedError
-
-    @property
-    def timezone(self) -> ZoneInfo:
-        """시간대"""
-        raise NotImplementedError
 
     @property
     def order_number(self) -> KisOrder:
@@ -192,7 +188,9 @@ class KisPendingOrders(KisAccountProtocol, Protocol):
     "execution",
     lines="multiple",
 )
-class KisPendingOrderBase(KisAccountProductBase):
+class KisPendingOrderBase(
+    KisAccountProductBase, KisOrderNumberEventFilter, KisRealtimeOrderableOrderImpl, KisOrderableOrderImpl
+):
     """한국투자증권 미체결 주식"""
 
     symbol: str
@@ -202,12 +200,32 @@ class KisPendingOrderBase(KisAccountProductBase):
     account_number: KisAccountNumber
     """계좌번호"""
 
+    @property
+    def branch(self) -> str:
+        """지점코드"""
+        return self.order_number.branch
+
+    @property
+    def number(self) -> str:
+        """주문번호"""
+        return self.order_number.number
+
     time: datetime
     """주문시각"""
     time_kst: datetime
     """주문시각(KST)"""
     timezone: ZoneInfo
     """시간대"""
+
+    @property
+    def pending(self) -> bool:
+        """미체결 여부"""
+        return True
+
+    @property
+    def pending_order(self) -> "KisPendingOrder | None":
+        """미체결 주문"""
+        return self
 
     order_number: KisOrder
     """주문번호"""
@@ -276,6 +294,81 @@ class KisPendingOrderBase(KisAccountProductBase):
     def pending_qty(self) -> ORDER_QUANTITY:
         """미체결수량"""
         return self.pending_quantity
+
+    @staticmethod
+    @deprecated("Use KisOrder.from_number() instead")
+    def from_number(
+        kis: "PyKis",
+        symbol: str,
+        market: MARKET_TYPE,
+        account_number: KisAccountNumber,
+        branch: str,
+        number: str,
+    ) -> "KisOrderNumber":
+        """
+        주문번호 생성
+
+        Args:
+            kis (PyKis): 한국투자증권 API
+            symbol (str): 종목코드
+            market (MARKET_TYPE): 상품유형
+            account_number (KisAccountNumber): 계좌번호
+            branch (str): 지점코드
+            number (str): 주문번호
+        """
+        return KisSimpleOrderNumber.from_number(
+            kis=kis,
+            symbol=symbol,
+            market=market,
+            account_number=account_number,
+            branch=branch,
+            number=number,
+        )
+
+    @staticmethod
+    @deprecated("Use KisOrder.from_order() instead")
+    def from_order(
+        kis: "PyKis",
+        symbol: str,
+        market: MARKET_TYPE,
+        account_number: KisAccountNumber,
+        branch: str,
+        number: str,
+        time_kst: datetime,
+    ) -> "KisOrder":
+        """
+        주문 생성
+
+        Args:
+            kis (PyKis): 한국투자증권 API
+            symbol (str): 종목코드
+            market (MARKET_TYPE): 상품유형
+            account_number (KisAccountNumber): 계좌번호
+            branch (str): 지점코드
+            number (str): 주문번호
+            time_kst (datetime): 주문시간 (한국시간)
+        """
+        return KisSimpleOrder.from_order(
+            kis=kis,
+            symbol=symbol,
+            market=market,
+            account_number=account_number,
+            branch=branch,
+            number=number,
+            time_kst=time_kst,
+        )
+
+    def __eq__(self, value: object | KisOrderNumber) -> bool:
+        return self.order_number == value
+
+    def __hash__(self) -> int:
+        return hash(self.order_number)
+
+
+if TYPE_CHECKING:
+    # IDE Type Checking
+    Checkable[KisOrderNumber](KisPendingOrderBase)
+    Checkable[KisOrder](KisPendingOrderBase)
 
 
 @kis_repr(
@@ -387,9 +480,7 @@ class KisDomesticPendingOrder(KisDynamic, KisPendingOrderBase):
     def __post_init__(self):
         super().__post_init__()
 
-        has_price, self.condition, self.execution = resolve_domestic_order_condition(
-            self.__data__["ord_dvsn_cd"]
-        )
+        has_price, self.condition, self.execution = resolve_domestic_order_condition(self.__data__["ord_dvsn_cd"])
 
         if not has_price:
             self.unit_price = None
@@ -397,7 +488,7 @@ class KisDomesticPendingOrder(KisDynamic, KisPendingOrderBase):
     def __kis_post_init__(self):
         super().__kis_post_init__()
 
-        self.order_number = KisOrder.from_order(
+        self.order_number = KisSimpleOrder.from_order(
             kis=self.kis,
             symbol=self.symbol,
             market=self.market,
@@ -501,7 +592,7 @@ class KisForeignPendingOrder(KisDynamic, KisPendingOrderBase):
     def __kis_post_init__(self):
         super().__kis_post_init__()
 
-        self.order_number = KisOrder.from_order(
+        self.order_number = KisSimpleOrder.from_order(
             kis=self.kis,
             symbol=self.symbol,
             market=self.market,
@@ -831,7 +922,5 @@ def account_product_pending_orders(
 
     return KisSimplePendingOrders(
         account_number=self.account_number,
-        orders=[
-            order for order in orders.orders if order.symbol == self.symbol and order.market == self.market
-        ],
+        orders=[order for order in orders.orders if order.symbol == self.symbol and order.market == self.market],
     )

--- a/pykis/api/websocket/order_execution.py
+++ b/pykis/api/websocket/order_execution.py
@@ -10,6 +10,7 @@ from pykis.api.account.order import (
     ORDER_TYPE,
     KisOrder,
     KisOrderNumber,
+    KisSimpleOrder,
     resolve_domestic_order_condition,
 )
 from pykis.api.base.account import KisAccountProtocol
@@ -225,9 +226,7 @@ class KisDomesticRealtimeOrderExecution(KisRealtimeExecutionBase):
         KisAny(KisAccountNumber)["account_number"],  # 1 ACNT_NO 계좌번호
         None,  # 2 ODER_NO 주문번호
         None,  # 3 OODER_NO 원주문번호
-        KisAny(lambda x: "sell" if x == "01" else "buy")[
-            "type"
-        ],  # 4 SELN_BYOV_CLS 매도매수구분 01 : 매도 02 : 매수
+        KisAny(lambda x: "sell" if x == "01" else "buy")["type"],  # 4 SELN_BYOV_CLS 매도매수구분 01 : 매도 02 : 매수
         None,  # 5 RCTF_CLS 정정구분
         None,  # 6 ODER_KIND 주문종류 00 : 지정가 01 : 시장가 02 : 조건부지정가 03 : 최유리지정가 04 : 최우선지정가 05 : 장전 시간외 06 : 장후 시간외 07 : 시간외 단일가 08 : 자기주식 09 : 자기주식S-Option 10 : 자기주식금전신탁 11 : IOC지정가 (즉시체결,잔량취소) 12 : FOK지정가 (즉시체결,전량취소) 13 : IOC시장가 (즉시체결,잔량취소) 14 : FOK시장가 (즉시체결,전량취소) 15 : IOC최유리 (즉시체결,잔량취소) 16 : FOK최유리 (즉시체결,전량취소)
         None,  # 7 ODER_COND 주문조건
@@ -323,7 +322,7 @@ class KisDomesticRealtimeOrderExecution(KisRealtimeExecutionBase):
     def __kis_post_init__(self):
         super().__kis_post_init__()
 
-        self.order_number = KisOrder.from_order(
+        self.order_number = KisSimpleOrder.from_order(
             kis=self.kis,
             symbol=self.symbol,
             market=self.market,
@@ -477,7 +476,7 @@ class KisForeignRealtimeOrderExecution(KisRealtimeExecutionBase):
     def __kis_post_init__(self):
         super().__kis_post_init__()
 
-        self.order_number = KisOrder.from_order(
+        self.order_number = KisSimpleOrder.from_order(
             kis=self.kis,
             symbol=self.symbol,
             market=self.market,

--- a/pykis/client/websocket.py
+++ b/pykis/client/websocket.py
@@ -30,7 +30,6 @@ from pykis.event.handler import (
     KisEventFilter,
     KisEventHandler,
     KisEventTicket,
-    KisLambdaEventFilter,
     KisMultiEventFilter,
 )
 from pykis.event.subscription import KisSubscribedEventArgs, KisSubscriptionEventArgs
@@ -302,9 +301,7 @@ class KisWebsocketClient:
         id: str,
         key: str,
         callback: Callable[["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]], None],
-        where: (
-            KisEventFilter["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]] | None
-        ) = None,
+        where: KisEventFilter["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]] | None = None,
         once: bool = False,
         primary: bool = False,
     ) -> KisEventTicket["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]]:

--- a/pykis/event/handler.py
+++ b/pykis/event/handler.py
@@ -158,11 +158,7 @@ class KisLambdaEventCallback(KisEventCallback[TSender, TEventArgs]):
         if self.where is None:
             return False
 
-        return (
-            self.where.__filter__(handler, sender, e)
-            if isinstance(self.where, KisEventFilter)
-            else self.where(sender, e)
-        )
+        return self.where.__filter__(handler, sender, e) if isinstance(self.where, KisEventFilter) else self.where(sender, e)
 
     def __callback__(self, handler: "KisEventHandler", sender: TSender, e: TEventArgs):
         if self.once:


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

`KisPendingOrder` 프로토콜에 `KisOrder`를 지원하도록 변경하였습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `pykis/adapter/account_product/order_modify.py` 파일을 추가했습니다.
  `KisCancelableOrder`, `KisModifyableOrder`, `KisOrderableOrder` 프로토콜 및 Mixin을 추가했습니다.
- `pykis/adapter/websocket/execution.py` 파일의 `KisRealtimeOrderableOrder`에 실시간 체결 조회 관련 함수를 추가하고, 기존 `KisOrderBase`에 해당 Mixin을 사용하였습니다.
- `pykis/api/account/pending_order.py` 파일의 `KisPendingOrder` 프로토콜에 `KisOrder` 프로토콜을 상속받도록 변경하고 KisPendingOrderBase에 해당 스펙을 충족하도록 구현하였습니다.
- `pykis/api/account/order.py` 파일의 `KisOrderNumberBase.__eq__` 함수에서 숫자 포메팅에 의한 불일치를 수정했습니다.

## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  PyKis의 예제 코드처럼 `pending_orders`를 조회하고 `KisPendingOrder` 객체에 바로 `cancel` 및 `modify`를 호출할 수 있도록 변경하였습니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  `KisPendingOrder`는 이제 `KisOrder`를 상속받습니다.
  실시간 주문번호 필터링이 의도대로 작동합니다.
