### PR TITLE
해외주식 실시간 체결 이벤트 버그 수정

### DIFF
--- a/pykis/api/account/order.py
+++ b/pykis/api/account/order.py
@@ -525,7 +525,7 @@ class KisOrderNumberBase(KisAccountProductBase, KisOrderNumberEventFilter):
                 self.account_number == value.account_number  # type: ignore
                 and self.symbol == value.symbol  # type: ignore
                 and self.market == value.market  # type: ignore
-                and self.branch == value.branch  # type: ignore
+                and (self.foreign or self.branch == value.branch)  # type: ignore
                 and int(self.number) == int(value.number)  # type: ignore
             )
         except AttributeError:

--- a/pykis/api/websocket/__init__.py
+++ b/pykis/api/websocket/__init__.py
@@ -3,7 +3,10 @@ from pykis.api.websocket.order_book import (
     KisDomesticRealtimeOrderbook,
     KisUSRealtimeOrderbook,
 )
-from pykis.api.websocket.order_execution import KisDomesticRealtimeOrderExecution
+from pykis.api.websocket.order_execution import (
+    KisDomesticRealtimeOrderExecution,
+    KisForeignRealtimeOrderExecution,
+)
 from pykis.api.websocket.price import KisDomesticRealtimePrice, KisForeignRealtimePrice
 from pykis.responses.websocket import KisWebsocketResponse
 
@@ -15,4 +18,6 @@ WEBSOCKET_RESPONSES_MAP: dict[str, type[KisWebsocketResponse]] = {
     "HDFSASP0": KisUSRealtimeOrderbook,
     "H0STCNI0": KisDomesticRealtimeOrderExecution,
     "H0STCNI9": KisDomesticRealtimeOrderExecution,
+    "H0GSCNI0": KisForeignRealtimeOrderExecution,
+    "H0GSCNI9": KisForeignRealtimeOrderExecution,
 }

--- a/pykis/api/websocket/order_execution.py
+++ b/pykis/api/websocket/order_execution.py
@@ -392,7 +392,9 @@ class KisForeignRealtimeOrderExecution(KisRealtimeExecutionBase):
         None,  # 12 CNTG_YN 체결여부 1:주문,정정,취소,거부 2:체결
         None,  # 13 ACPT_YN 접수여부 1:주문접수 2:확인 3:취소(FOK/IOC)
         None,  # 14 BRNC_NO 지점번호
-        KisDecimal["quantity"],  # 15 ODER_QTY 주문수량
+        KisDecimal[
+            "quantity", Decimal(-1)
+        ],  # 15 ODER_QTY 주문수량 ,주문통보인 경우 해당 위치 미출력 (주문통보의 주문수량은 CNTG_QTY 위치에 출력). 체결통보인 경우 해당 위치에 주문수량이 출력
         None,  # 16 ACNT_NAME 계좌명
         None,  # 17 CNTG_ISNM 체결종목명
         KisAny(FOREIGN_MARKET_CODE_MAP.__getitem__)[
@@ -468,6 +470,9 @@ class KisForeignRealtimeOrderExecution(KisRealtimeExecutionBase):
         self.time_kst = datetime.now(TIMEZONE)
         self.timezone = get_market_timezone(self.market)
         self.time = self.time_kst.astimezone(self.timezone)
+
+        if self.quantity < 0:
+            self.quantity = self.executed_quantity
 
         if self.receipt:
             self.quantity = self.executed_quantity

--- a/pykis/event/filters/order.py
+++ b/pykis/event/filters/order.py
@@ -149,7 +149,7 @@ class KisOrderNumberEventFilter(KisEventFilter["KisWebsocketClient", KisSubscrip
         return not (
             order.symbol == value.symbol
             and order.market == value.market
-            and order.branch == value.branch
+            and (order.foreign or order.branch == value.branch)
             and int(order.number) == int(value.number)
             and order.account_number == value.account_number
         )


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

정상적으로 해외주식 실시간 체결 이벤트를 수신할 수 있습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `pykis/api/account/order.py` 및 `pykis/event/filters/order.py`에서 해외 주문번호의 지점코드(원주문번호)를 비교하지 않도록 변경하였습니다.
- `pykis/responses/websocket.py`의 `KisWebsocketResponse` 파싱 로직에 `KisType.default` 값을 활용하도록 변경하였습니다.
- `pykis/api/websocket/order_execution.py`의 `KisForeignRealtimeOrderExecution`에서 접수 주문시 `ODER_QTY`가 없을 때 발생하는 파싱 오류를 해결했습니다.


## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  정상적으로 해외주식 실시간 체결 이벤트를 수신할 수 있습니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  정상적으로 해외주식 실시간 체결 응답을 파싱하고, 필터링 및 이벤트를 수신할 수 있습니다.
