### PR TITLE
이벤트 티켓 암시적 구독 해지 경고 메시지 추가

### DIFF
--- a/pykis/api/websocket/order_execution.py
+++ b/pykis/api/websocket/order_execution.py
@@ -394,7 +394,7 @@ class KisForeignRealtimeOrderExecution(KisRealtimeExecutionBase):
         None,  # 14 BRNC_NO 지점번호
         KisDecimal[
             "quantity", Decimal(-1)
-        ],  # 15 ODER_QTY 주문수량 ,주문통보인 경우 해당 위치 미출력 (주문통보의 주문수량은 CNTG_QTY 위치에 출력). 체결통보인 경우 해당 위치에 주문수량이 출력
+        ],  # 15 ODER_QTY 주문수량, 주문통보인 경우 해당 위치 미출력 (주문통보의 주문수량은 CNTG_QTY 위치에 출력). 체결통보인 경우 해당 위치에 주문수량이 출력
         None,  # 16 ACNT_NAME 계좌명
         None,  # 17 CNTG_ISNM 체결종목명
         KisAny(FOREIGN_MARKET_CODE_MAP.__getitem__)[

--- a/pykis/event/filters/product.py
+++ b/pykis/event/filters/product.py
@@ -44,9 +44,7 @@ class KisSimpleProduct:
         self.market = market
 
 
-class KisProductEventFilter(
-    KisEventFilterBase["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]]
-):
+class KisProductEventFilter(KisEventFilterBase["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]]):
 
     _product: KisSimpleProductProtocol
 
@@ -93,3 +91,12 @@ class KisProductEventFilter(
             and e.response.symbol == self._product.symbol
             and e.response.market == self._product.market
         )
+
+    def __hash__(self) -> int:
+        return hash((self.__class__, self._product))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(symbol={self._product.symbol!r}, market={self._product.market!r})"
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/pykis/event/filters/subscription.py
+++ b/pykis/event/filters/subscription.py
@@ -13,9 +13,7 @@ __all__ = [
 ]
 
 
-class KisSubscriptionEventFilter(
-    KisEventFilterBase["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]]
-):
+class KisSubscriptionEventFilter(KisEventFilterBase["KisWebsocketClient", KisSubscriptionEventArgs[TWebsocketResponse]]):
     """TR 구독 이벤트 필터"""
 
     __slots__ = ("id", "key")
@@ -34,3 +32,9 @@ class KisSubscriptionEventFilter(
 
     def __hash__(self) -> int:
         return hash((self.__class__, self.id, self.key))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(id={self.id!r}, key={self.key!r})"
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/pykis/event/handler.py
+++ b/pykis/event/handler.py
@@ -262,10 +262,12 @@ class KisEventTicket(Generic[TSender, TEventArgs]):
     def __del__(self):
         if not self._suppress_del:
             # 2.1.1 버전 이후부터는 티켓을 명시적으로 해지하지 않으면 경고 메시지를 출력합니다.
-            warnings.warn(
-                f"Event ticket {self} was not explicitly unsubscribed, but was unsubscribed due to a resource release.",
-                UserWarning,
-            )
+            if self.registered:
+                warnings.warn(
+                    f"Event ticket {self} was not explicitly unsubscribed, but was unsubscribed due to a resource release.",
+                    UserWarning,
+                )
+
             self.unsubscribe()
 
     def __repr__(self):

--- a/pykis/event/handler.py
+++ b/pykis/event/handler.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import (
     Callable,
@@ -88,6 +89,12 @@ class KisLambdaEventFilter(KisEventFilterBase[TSender, TEventArgs]):
     def __hash__(self) -> int:
         return hash(self.filter)
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.filter!r})"
+
+    def __str__(self) -> str:
+        return repr(self)
+
 
 class KisMultiEventFilter(KisEventFilterBase[TSender, TEventArgs]):
     """다중 이벤트 필터"""
@@ -117,6 +124,12 @@ class KisMultiEventFilter(KisEventFilterBase[TSender, TEventArgs]):
 
     def __hash__(self) -> int:
         return hash((self.filters, self.gate))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({", ".join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"
+
+    def __str__(self) -> str:
+        return repr(self)
 
 
 class KisEventCallback(KisEventFilterBase[TSender, TEventArgs], metaclass=ABCMeta):
@@ -175,6 +188,12 @@ class KisLambdaEventCallback(KisEventCallback[TSender, TEventArgs]):
 
     def __del__(self):
         release_method(self.callback)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.callback!r}, where={self.where!r}, once={self.once!r})"
+
+    def __str__(self) -> str:
+        return repr(self)
 
 
 EventCallback = Callable[[TSender, TEventArgs], None] | KisEventCallback[TSender, TEventArgs]
@@ -245,7 +264,7 @@ class KisEventTicket(Generic[TSender, TEventArgs]):
             self.unsubscribe()
 
     def __repr__(self):
-        return f"<EventTicket {self.callback}>"
+        return f"<{self.__class__.__name__} callback={self.callback}>"
 
     def __str__(self):
         return repr(self)
@@ -370,7 +389,7 @@ class KisEventHandler(Generic[TSender, TEventArgs]):
         return bool(self.handlers)
 
     def __repr__(self):
-        return f"<EventHandler {len(self.handlers)} handlers>"
+        return f"<{self.__class__.__name__} {len(self.handlers)} handlers>"
 
     def __str__(self):
         return repr(self)

--- a/pykis/event/handler.py
+++ b/pykis/event/handler.py
@@ -261,6 +261,11 @@ class KisEventTicket(Generic[TSender, TEventArgs]):
 
     def __del__(self):
         if not self._suppress_del:
+            # 2.1.1 버전 이후부터는 티켓을 명시적으로 해지하지 않으면 경고 메시지를 출력합니다.
+            warnings.warn(
+                f"Event ticket {self} was not explicitly unsubscribed, but was unsubscribed due to a resource release.",
+                UserWarning,
+            )
             self.unsubscribe()
 
     def __repr__(self):


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

티켓을 명시적으로 구독해지하지 않으면 경고를 발생하는 로직을 추가했습니다.

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- `pykis/event/handler.py`, `pykis/event/filters/product.py` 파일의 이벤트 필터 객체에 repr 함수를 추가했습니다.
- `pykis/event/handler.py`의 `__del__`함수에 명시적으로 해지되지 않았다면 경고를 출력하도록 수정했습니다.

## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  티켓을 명시적으로 구독 해지하지 않으면 경고를 발생하여 사용자에게 알립니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  의도치 않게 구독 해지 되었을 때 문제를 추적할 수 있습니다.
