### PR TITLE
fix: SyntaxError: f-string: expecting '}' but got "}"

### DIFF
--- a/pykis/event/handler.py
+++ b/pykis/event/handler.py
@@ -126,7 +126,7 @@ class KisMultiEventFilter(KisEventFilterBase[TSender, TEventArgs]):
         return hash((self.filters, self.gate))
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({", ".join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"
+        return f"{self.__class__.__name__}({', '.join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"
 
     def __str__(self) -> str:
         return repr(self)


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
어떤 것이 변경되었나요? 간략히 설명해주세요.

다음 오류를 수정했습니다.

```
  File "/home/tasoo1118/.miniconda3/envs/algotrading/lib/python3.11/site-packages/pykis/event/handler.py", line 129
    return f"{self.__class__.__name__}({", ".join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"
                                         ^
SyntaxError: f-string: expecting '}'
```

## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

해당 줄의 내부 쌍따옴표를 외따음표로 변경했습니다.

`return f"{self.__class__.__name__}({", ".join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"`
`return f"{self.__class__.__name__}({', '.join(repr(filter) for filter in self.filters)}, gate={self.gate!r})"`


## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?
  파이썬 3.11 버전에서 에러가 납니다.

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
  이 변경사항이 최선인지는 잘 모르겠습니다. 
  그래도 에러는 이제 안 납니다.