### PR TITLE
Fix/balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ tests/vack.txt
 tests/vacco.txt
 dummy/
 .env
+
+.DS_Store
+
+real_secret.json
+virtual_secret.json

--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -629,10 +629,13 @@ class KisForeignPresentBalanceStock(KisDynamic, KisBalanceStockBase):
     """매도가능수량"""
 
     purchase_amount: Decimal = KisDecimal["frcr_pchs_amt"]
-    """매입금액"""
+    """매입금액(외화)"""
 
     exchange_rate: Decimal = KisDecimal["bass_exrt"]
     """환율"""
+
+    purchase_krw_amount: Decimal = KisDecimal["pchs_rmnd_wcrc_amt"]
+    """매입금액(원화)"""
 
 
 class KisForeignPresentDeposit(KisDynamic, KisDepositBase):

--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -87,6 +87,11 @@ class KisBalanceStock(
         ...
 
     @property
+    def purchase_amount_krw(self) -> Decimal:
+        """매입금액(원화)"""
+        ...
+
+    @property
     def current_amount(self) -> Decimal:
         """평가금액"""
         ...
@@ -516,6 +521,9 @@ class KisDomesticBalanceStock(KisDynamic, KisBalanceStockBase):
     purchase_amount: Decimal = KisDecimal["pchs_amt"]
     """매입금액"""
 
+    purchase_amount_krw: Decimal = KisDecimal["pchs_amt"]
+    """매입금액(원화)"""
+
     exchange_rate: Decimal = Decimal(1)
     """환율"""
 
@@ -750,6 +758,11 @@ class KisForeignBalanceStock(KisDynamic, KisBalanceStockBase):
 
     purchase_amount: Decimal = KisDecimal["frcr_pchs_amt1"]
     """매입금액"""
+
+    @property
+    def purchase_amount_krw(self) -> Decimal:
+        """매입금액(원화, 당시 환율 조회 불가)"""
+        return self.purchase_amount * self.exchange_rate
 
     # Pylance bug: cached_property[Decimal] type inference error.
     @cached_property
@@ -1062,9 +1075,9 @@ def foreign_balance(
             country=country,
         ).stocks
 
-        for stock in result.stocks:
-            if isinstance(stock, KisBalanceStockBase):
-                stock.balance = result
+    for stock in result.stocks:
+        if isinstance(stock, KisBalanceStockBase):
+            stock.balance = result
 
     return result
 

--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -623,7 +623,7 @@ class KisForeignPresentBalanceStock(KisDynamic, KisBalanceStockBase):
     current_price: Decimal = KisDecimal["ovrs_now_pric1"]
     """현재가"""
 
-    quantity: ORDER_QUANTITY = KisDecimal["cblc_qty13"]
+    quantity: ORDER_QUANTITY = KisDecimal["ccld_qty_smtl1"]
     """수량"""
     orderable: ORDER_QUANTITY = KisDecimal["ord_psbl_qty1"]
     """매도가능수량"""
@@ -1052,19 +1052,16 @@ def foreign_balance(
         ),
     )
 
-    # Issue #41 - [버그]: KisIntegrationBalance에서 해외주식 잔고수량이 0으로 표시됨
-    # https://apiportal.koreainvestment.com/apiservice/apiservice-oversea-stock-order#L_09baff2a-6e9d-4502-ba66-d7bb94094b67
-    # 위 Docs와 같이 "잔고 확인을 원하실 경우에는 해외주식 잔고[v1_해외주식-006] API 사용을 부탁드립니다.)" 라고 되어있음
+    if self.virtual:
+        result.stocks = _foreign_balance(
+            self,
+            account=account,
+            country=country,
+        ).stocks
 
-    result.stocks = _foreign_balance(
-        self,
-        account=account,
-        country=country,
-    ).stocks
-
-    for stock in result.stocks:
-        if isinstance(stock, KisBalanceStockBase):
-            stock.balance = result
+        for stock in result.stocks:
+            if isinstance(stock, KisBalanceStockBase):
+                stock.balance = result
 
     return result
 

--- a/pykis/api/account/balance.py
+++ b/pykis/api/account/balance.py
@@ -642,7 +642,7 @@ class KisForeignPresentBalanceStock(KisDynamic, KisBalanceStockBase):
     exchange_rate: Decimal = KisDecimal["bass_exrt"]
     """환율"""
 
-    purchase_krw_amount: Decimal = KisDecimal["pchs_rmnd_wcrc_amt"]
+    purchase_amount_krw: Decimal = KisDecimal["pchs_rmnd_wcrc_amt"]
     """매입금액(원화)"""
 
 


### PR DESCRIPTION
# 🛠️ PR Summary

## 🌟 요약
- 해외주식 "매입 잔액 원화 금액" 을 가져올 수 있도록 했습니다.
- [해외주식 잔고를 가져올 때 해외주식 체결기준현재잔고를 사용하도록 롤백 했습니다 ](https://github.com/Soju06/python-kis/issues/41)
- 체결기준 현재 잔고 API 를 사용할 때 clbc_qty13(결제보유수량) 대신 ccld_qty_smtl1(체결기준 현재 보유수량) 을 사용하도록 수정했습니다.



## 📊 주요 변경 사항
주요 변경 사항을 적어주세요.

- balance.py
  - KisForeignPresentBalanceStock 의 quantity 에 clbc_qty13(결제보유수량) 대신 ccld_qty_smtl1(체결기준 현재 보유수량) 을 사용하도록 수정했습니다.
  - foreign_balance 를 실행할 때 항상 _foreign_balance 가 실행되는게 아닌 모의 투자일 때만 실행되도로 수정했습니다.
  - KisForeignPresentBalanceStock 에 purchase_krw_amount 프로퍼티를 추가하였습니다.



## 🎯 목적 및 영향

- 목적: 왜 이 PR이 필요한가요?

"해외주식 체결기준 현재 잔고 API"를 사용하지 않고 항상 "해외주식 잔고 API"를 사용하면 해외주식 구매했을 때 원화금액을 알 수 없습니다. (환율 이슈) ㅠ

- 영향: 이 변경 사항이 어떤 영향을 미치나요?
[이슈](https://github.com/Soju06/python-kis/issues/41#issuecomment-2301227422) 내부 출력 결과를 보았을때 체결기준으로 ccld_qty_smtl1 값은 3으로 정상적으로 수량이 표시된 것으로 보입니다. clbc_qty13 는 2 영업일 이후에 반영되는 값으로 0이 정상으로 나오는게 맞는 거 같습니다. 
ccld_qty_smtl1(체결수량합계) = cblc_qty13(잔고수량) + thdt_buy_ccld_qty1(당일매수체결수량) - thdt_sll_ccld_qty1(당일매도체결수량)
